### PR TITLE
Add ability to parce brace enclosed tokens

### DIFF
--- a/mod_translation_updater.py
+++ b/mod_translation_updater.py
@@ -122,7 +122,7 @@ def main():
 def compile_func_call_pattern(argument_pattern):
 	return re.compile(
 		# Look for beginning of file or anything that isn't a function identifier
-		r'(?:^|[\.=,\[{\(\s])' +
+		r'(?<![a-zA-Z0-9_])' +
 		# Matches S, FS, NS, or NFS function call
 		r'N?F?S\s*' +
 		# The pattern to match argument

--- a/mod_translation_updater.py
+++ b/mod_translation_updater.py
@@ -122,7 +122,7 @@ def main():
 def compile_func_call_pattern(argument_pattern):
 	return re.compile(
 		# Look for beginning of file or anything that isn't a function identifier
-		r'(?:^|[\.=,{\(\s])' +
+		r'(?:^|[\.=,\[{\(\s])' +
 		# Matches S, FS, NS, or NFS function call
 		r'N?F?S\s*' +
 		# The pattern to match argument


### PR DESCRIPTION
Currently is not possible to find `[NS("Strings")]`. This change allows just that.

Here is [an example](/minetest-mods/character_creator/blob/084b67d212717df9573dbe816630af423b02d4ac/skins.lua#L5) translation source.